### PR TITLE
Define protocol between web and worker

### DIFF
--- a/worker/src/channel.js
+++ b/worker/src/channel.js
@@ -1,0 +1,51 @@
+class Channel {
+  constructor(channelCallback) {
+    this.channelCallback = channelCallback;
+  }
+
+  poseQuestion(question, answers, round) {
+    this.channelCallback({
+      type: "question",
+      question,
+      answers,
+      round,
+    });
+  }
+
+  reportCountDown(timeLeft) {
+    this.channelCallback({
+      type: "countDown",
+      timeLeft,
+    });
+  }
+
+  reportResults(
+    question,
+    answers,
+    correctAnswerIndex,
+    answerCounts,
+    eliminatedPlayerIds,
+    round
+  ) {
+    this.channelCallback({
+      type: "results",
+      question,
+      answers,
+      correctAnswerIndex,
+      answerCounts,
+      eliminatedPlayerIds,
+      round,
+    });
+  }
+
+  endGame(winners) {
+    this.channelCallback({
+      type: "end",
+      winners,
+    });
+  }
+}
+
+module.exports = {
+  Channel,
+};

--- a/worker/tests/channel.spec.js
+++ b/worker/tests/channel.spec.js
@@ -1,0 +1,77 @@
+const { Channel } = require("../src/channel.js");
+
+describe("Channel", () => {
+  test("postQuestion posts a question to the channel", () => {
+    const cb = jest.fn();
+    const channel = new Channel(cb);
+
+    channel.poseQuestion("?", ["A", "B", "C"], 1);
+    expect(cb.mock.calls).toEqual([
+      [
+        {
+          type: "question",
+          question: "?",
+          answers: ["A", "B", "C"],
+          round: 1,
+        },
+      ],
+    ]);
+  });
+
+  test("reportCountDown reports the time left to the channel", () => {
+    const cb = jest.fn();
+    const channel = new Channel(cb);
+
+    channel.reportCountDown(500);
+    expect(cb.mock.calls).toEqual([
+      [
+        {
+          type: "countDown",
+          timeLeft: 500,
+        },
+      ],
+    ]);
+  });
+
+  test("reportResults reports results to the channel", () => {
+    const cb = jest.fn();
+    const channel = new Channel(cb);
+
+    channel.reportResults(
+      "?",
+      ["A", "B", "C"],
+      2,
+      { "0": 1, "1": 2, "2": 500 },
+      ["p1", "p2", "p3"],
+      1
+    );
+    expect(cb.mock.calls).toEqual([
+      [
+        {
+          type: "results",
+          question: "?",
+          answers: ["A", "B", "C"],
+          correctAnswerIndex: 2,
+          answerCounts: { "0": 1, "1": 2, "2": 500 },
+          eliminatedPlayerIds: ["p1", "p2", "p3"],
+          round: 1,
+        },
+      ],
+    ]);
+  });
+
+  test("endGame reports winners to the channel", () => {
+    const cb = jest.fn();
+    const channel = new Channel(cb);
+
+    channel.endGame({ p1: "Washington", p2: "Irving", p3: "John" });
+    expect(cb.mock.calls).toEqual([
+      [
+        {
+          type: "end",
+          winners: { p1: "Washington", p2: "Irving", p3: "John" },
+        },
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
This change defines the communication protocol between the web frontend and the worker and adds a simple class that encapsulates that protocol.

The protocol has several parts:

* The worker needs to report the next question to the web frontends so that they can report that to their clients
* The worker needs to periodically report on the time left when a timer is counting down to help clients synchronize their own timers
* The worker needs to report the results of a current round so that web frontends can update the state of their clients and so that clients can show statistics of the end of the round
* The worker needs to report when a game ends and which players have won.

A centralized object helps make this protocol clear.