### PR TITLE
`hgetall` returns `null` when the key isn't present

### DIFF
--- a/worker/src/gameUtils.js
+++ b/worker/src/gameUtils.js
@@ -33,7 +33,11 @@ async function getPlayerAnswers(redisClient, gameId, round) {
   const hgetall = promisify(redisClient.hgetall.bind(redisClient));
 
   const key = `${gameId}:${round}`;
-  const answers = await hgetall(key);
+  let answers = await hgetall(key);
+  if (!answers) {
+    answers = [];
+  }
+
   const playerAnswers = {};
   for (let index = 0; index < answers.length; index += 2) {
     playerAnswers[answers[index]] = parseInt(answers[index + 1], 10);

--- a/worker/tests/gameUtils.spec.js
+++ b/worker/tests/gameUtils.spec.js
@@ -59,7 +59,7 @@ describe("getPlayerAnswers", () => {
   });
 
   test("returns an empty answer object when no answers are given", async () => {
-    const redisClient = new StubRedisClient({ "1:0": [] });
+    const redisClient = new StubRedisClient({ "1:0": null });
     const answers = await getPlayerAnswers(redisClient, "1", 0);
     expect(answers).toEqual({});
   });


### PR DESCRIPTION
Contrary to what I understood from the `node_redis` documentation, the `hgetall` message returns `null` when the key isn't present rather than an empty array. This change ensures that we detect this case and use an empty array.