### PR TITLE
hgetall returns an object, not a list

### DIFF
--- a/worker/src/gameUtils.js
+++ b/worker/src/gameUtils.js
@@ -33,14 +33,13 @@ async function getPlayerAnswers(redisClient, gameId, round) {
   const hgetall = promisify(redisClient.hgetall.bind(redisClient));
 
   const key = `${gameId}:${round}`;
-  let answers = await hgetall(key);
-  if (!answers) {
-    answers = [];
+  let playerAnswers = await hgetall(key);
+  if (!playerAnswers) {
+    playerAnswers = {};
   }
 
-  const playerAnswers = {};
-  for (let index = 0; index < answers.length; index += 2) {
-    playerAnswers[answers[index]] = parseInt(answers[index + 1], 10);
+  for (let playerId of Object.keys(playerAnswers)) {
+    playerAnswers[playerId] = parseInt(playerAnswers[playerId], 10);
   }
 
   return playerAnswers;

--- a/worker/tests/game.spec.js
+++ b/worker/tests/game.spec.js
@@ -49,9 +49,9 @@ describe("processGame", () => {
 
   test("has one round per question", async () => {
     const redisClient = new StubRedisClient({
-      "1:0": ["p1", "0", "p2", "0", "p3", "0"],
-      "1:1": ["p1", "0", "p2", "1", "p3", "0"],
-      "1:2": ["p1", "0", "p3", "1"],
+      "1:0": { p1: "0", p2: "0", p3: "0" },
+      "1:1": { p1: "0", p2: "1", p3: "0" },
+      "1:2": { p1: "0", p3: "1" },
     });
 
     await processGame(1, players, redisClient, questions, channelCallback);
@@ -65,9 +65,9 @@ describe("processGame", () => {
 
   test("ends the game early if there are no active players", async () => {
     const redisClient = new StubRedisClient({
-      "1:0": ["p1", "0", "p2", "0", "p3", "0"],
-      "1:1": ["p1", "1", "p2", "1", "p3", "1"],
-      "1:2": ["p1", "0", "p3", "1"],
+      "1:0": { p1: "0", p2: "0", p3: "0" },
+      "1:1": { p1: "1", p2: "1", p3: "1" },
+      "1:2": { p1: "0", p3: "1" },
     });
 
     await processGame(1, players, redisClient, questions, channelCallback);
@@ -85,9 +85,9 @@ describe("processGame", () => {
 
   test("reports winning player names and IDs", async () => {
     const redisClient = new StubRedisClient({
-      "1:0": ["p1", "0", "p2", "0", "p3", "0"],
-      "1:1": ["p1", "0", "p2", "1", "p3", "1"],
-      "1:2": ["p1", "0", "p3", "1"],
+      "1:0": { p1: "0", p2: "0", p3: "0" },
+      "1:1": { p1: "0", p2: "1", p3: "1" },
+      "1:2": { p1: "0", p3: "1" },
     });
 
     await processGame(1, players, redisClient, questions, channelCallback);
@@ -135,7 +135,7 @@ describe("processRound", () => {
 
   test("reports state to the channel", async () => {
     const redisClient = new StubRedisClient({
-      "1:0": ["p1", "0", "p2", "0", "p3", "0"],
+      "1:0": { p1: "0", p2: "0", p3: "0" },
     });
 
     const playerState = new PlayerState([
@@ -190,7 +190,7 @@ describe("processRound", () => {
 
   test("eliminates players who answer incorrectly", async () => {
     const redisClient = new StubRedisClient({
-      "1:0": ["p1", "0", "p2", "1", "p3", "0"],
+      "1:0": { p1: "0", p2: "1", p3: "0" },
     });
 
     const playerState = new PlayerState([

--- a/worker/tests/gameUtils.spec.js
+++ b/worker/tests/gameUtils.spec.js
@@ -52,10 +52,10 @@ describe("getAnswerCounts", () => {
 describe("getPlayerAnswers", () => {
   test("gets all player answers", async () => {
     const redisClient = new StubRedisClient({
-      "1:0": ["1", "0", "2", "0", "3", "1"],
+      "1:0": { p1: "0", p2: "0", p3: "1" },
     });
     const answers = await getPlayerAnswers(redisClient, "1", 0);
-    expect(answers).toEqual({ "1": 0, "2": 0, "3": 1 });
+    expect(answers).toEqual({ p1: 0, p2: 0, p3: 1 });
   });
 
   test("returns an empty answer object when no answers are given", async () => {


### PR DESCRIPTION
This change fixes an issue with how `hgetall` was used. Similar to before, the documentation implied a different output type than was expected - the library does format the result as an object (which is what we want anyway) and not a list as Redis returns.