### PR TITLE
Reduce the number of time sync messages

### DIFF
--- a/worker/src/game.js
+++ b/worker/src/game.js
@@ -61,7 +61,7 @@ async function processGame(
   console.log(`Starting game gameId="${gameId}"`);
 
   const channel = new Channel(channelCallback);
-  const gameTimer = makeCountDown(10000, 250, channel);
+  const gameTimer = makeCountDown(10000, 1000, channel);
   const playerState = new PlayerState(players);
 
   const curryRound = (round, question) =>


### PR DESCRIPTION
Based on local testing a locally running timer appears to track very closely to the server-side timer. I've chosen to reduce the number of timer synchronization messages down to once per second in order to reduce the bandwidth the service will take.

This value could be driven even lower but I chose a synchronization every second for usability reasons. I plan on a timer that shows a count down with tenths of a second and I want to make sure there are no major jumps in that timer. Tenths of a second are fast enough that someone might see a one second jump as strange but second guess whether they saw an issue or if they didn't see the timer correctly. A two second jump is likely to be much more visible.

I also want to take into account that my local testing is on a desktop whereas I don't yet know how well a local timer would track on a mobile device which might have different timer characteristics due to battery life optimizations.