### PR TITLE
Notify players that the game will start

### DIFF
--- a/worker/src/channel.js
+++ b/worker/src/channel.js
@@ -3,6 +3,14 @@ class Channel {
     this.channelCallback = channelCallback;
   }
 
+  startGame(players, gameId) {
+    this.channelCallback({
+      type: "start",
+      players,
+      gameId,
+    });
+  }
+
   poseQuestion(question, answers, round) {
     this.channelCallback({
       type: "question",

--- a/worker/src/game.js
+++ b/worker/src/game.js
@@ -75,6 +75,10 @@ async function processGame(
       gameTimer
     );
 
+  channel.startGame(players, gameId);
+
+  await gameTimer();
+
   for (let round = 0; round < questions.length; ++round) {
     const question = questions[round];
     const hasActivePlayers = await curryRound(round, question);

--- a/worker/tests/channel.spec.js
+++ b/worker/tests/channel.spec.js
@@ -1,6 +1,37 @@
 const { Channel } = require("../src/channel.js");
 
 describe("Channel", () => {
+  test("startGame reports the players and the gameId to the channel", () => {
+    const cb = jest.fn();
+    const channel = new Channel(cb);
+
+    const players = [
+      {
+        id: "p1",
+        name: "Washington",
+      },
+      {
+        id: "p2",
+        name: "Irving",
+      },
+      {
+        id: "p3",
+        name: "John",
+      },
+    ];
+
+    channel.startGame(players, "A");
+    expect(cb.mock.calls).toEqual([
+      [
+        {
+          type: "start",
+          players,
+          gameId: "A",
+        },
+      ],
+    ]);
+  });
+
   test("postQuestion posts a question to the channel", () => {
     const cb = jest.fn();
     const channel = new Channel(cb);

--- a/worker/tests/game.spec.js
+++ b/worker/tests/game.spec.js
@@ -47,6 +47,24 @@ describe("processGame", () => {
     channelCallback = jest.fn();
   });
 
+  test("notifies players when the game starts", async () => {
+    const redisClient = new StubRedisClient({
+      "1:0": null,
+    });
+
+    await processGame(1, players, redisClient, questions, channelCallback);
+
+    expect(channelCallback).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ type: "start" })
+    );
+    const startNotifications = channelCallback.mock.calls
+      .map((call) => call[0])
+      .filter((call) => call.type === "start").length;
+
+    expect(startNotifications).toBe(1);
+  });
+
   test("has one round per question", async () => {
     const redisClient = new StubRedisClient({
       "1:0": { p1: "0", p2: "0", p3: "0" },


### PR DESCRIPTION
This change adds two new notifications from the game worker: one that the game starting and who is participating and a count down before the first question is shown.

These notifications are needed for several reasons:

* The game start notification notifies each web frontend about which players are participating in the game. Since games are started by a single web frontend and that web frontend doesn't have access to the state of the others this information has to come from the worker as it's the only place that knows this information and can communicate it to all interested parties.

There might be a concern that with a large number of players we will be sending a large amount of data to each web frontend. If we allow names to contain 40 characters and IDs to be 16 bytes then the information for 1000 players only takes up about 100kb (40 characters in JavaScript is 80 bytes). This is a small amount of information to deposit in the single Redis pub/sub channel that the web frontends read from.

Next, this event also allows the client applications to update their state to let users know that their game is about to start.

Finally, the count down gives those users time to get ready for their first question.