### PR TITLE
Add object to abstract Redis operations

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,5 +13,8 @@
     "redis": "2.7.1",
     "utf-8-validate": "^5.0.2",
     "ws": "^7.2.3"
+  },
+  "devDependencies": {
+    "redis-mock": "^0.49.0"
   }
 }

--- a/web/src/redisDataStore.js
+++ b/web/src/redisDataStore.js
@@ -1,0 +1,79 @@
+const { promisify } = require("util");
+
+const WAITING_AREA_KEY = "web:waiting";
+const WAITING_AREA_LOCK_KEY = "web:waiting:lock";
+
+class RedisDataStore {
+  constructor(redisClient) {
+    this.redisClient = redisClient;
+
+    this._llen = promisify(this.redisClient.llen.bind(this.redisClient));
+    this._lrange = promisify(this.redisClient.lrange.bind(this.redisClient));
+    this._rpush = promisify(this.redisClient.rpush.bind(this.redisClient));
+    this._watch = promisify(this.redisClient.watch.bind(this.redisClient));
+  }
+
+  async addPlayerToWaitingArea(player) {
+    const playerWithId = `${player.id}:${player.name}`;
+    return await this._rpush(WAITING_AREA_KEY, playerWithId);
+  }
+
+  async removePlayersFromWaitingArea() {
+    await this._watch(WAITING_AREA_LOCK_KEY);
+
+    const playerCount = await this._llen(WAITING_AREA_KEY);
+    const playerData = await this._lrange(WAITING_AREA_KEY, 0, playerCount - 1);
+
+    const players = playerData.map((playerWithId) => {
+      const [playerId, playerName] = playerWithId.split(":");
+      return {
+        id: playerId,
+        name: playerName,
+      };
+    });
+
+    const preempted = await new Promise((resolve, reject) => {
+      this.redisClient
+        .multi()
+
+        // Remove the first playerCount indicies from the list
+        // (keep everything from index playerCount to the end)
+        .ltrim(WAITING_AREA_KEY, playerCount, -1)
+        .incr(WAITING_AREA_LOCK_KEY)
+        .exec((err, results) => {
+          if (err) {
+            reject(err);
+          } else if (results === null) {
+            console.log("Game started by another instance");
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        });
+    });
+
+    return Promise.resolve({ players, preempted });
+  }
+
+  async setPlayerAnswer(playerId, answerIndex, gameId, round) {
+    const key = `${gameId}:${round}`;
+
+    return new Promise((resolve, reject) => {
+      this.redisClient
+        .multi()
+        .hset(key, playerId, answerIndex)
+        .expire(key, 20)
+        .exec((err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+}
+
+module.exports = {
+  RedisDataStore,
+};

--- a/web/tests/redisDataStore.spec.js
+++ b/web/tests/redisDataStore.spec.js
@@ -1,0 +1,144 @@
+const redis = require("redis-mock");
+const { RedisDataStore } = require("../src/redisDataStore.js");
+
+const WAITING_AREA_KEY = "web:waiting";
+
+describe("RedisDataStore", () => {
+  let redisDataStore;
+  let redisClient;
+  beforeEach(() => {
+    redisClient = redis.createClient();
+
+    // redis-mock doesn't yet implement watch so we'll add a simple
+    // implementation here that just resolves.
+    redisClient.watch = (key, cb) => cb(undefined);
+
+    redisDataStore = new RedisDataStore(redisClient);
+  });
+
+  afterEach((done) => {
+    redisClient.flushall();
+    redisClient.quit(done);
+  });
+
+  describe("addPlayerToWaitingArea", () => {
+    test("adds a player to an empty waiting area", async () => {
+      const player = { id: "A", name: "Washington" };
+      const waitingPlayerCount = await redisDataStore.addPlayerToWaitingArea(
+        player
+      );
+
+      expect(waitingPlayerCount).toBe(1);
+    });
+
+    test("adds a player to the end of the waiting area", async () => {
+      const p1 = { id: "A", name: "Washington" };
+      await redisDataStore.addPlayerToWaitingArea(p1);
+
+      const p2 = { id: "B", name: "Irving" };
+      const waitingPlayerCount = await redisDataStore.addPlayerToWaitingArea(
+        p2
+      );
+
+      expect(waitingPlayerCount).toBe(2);
+
+      const lastPlayer = await new Promise((resolve) => {
+        redisClient.rpop(WAITING_AREA_KEY, (err, result) => resolve(result));
+      });
+
+      expect(lastPlayer).toEqual("B:Irving");
+    });
+  });
+
+  // This method has a lot of logic to handle concurrent usage of the waiting
+  // area. Since these tests don't allow for concurrent usage they aren't
+  // sufficient to test the most interesting cases this method handles.
+  describe("removePlayersFromWaitingArea", () => {
+    async function getPlayersInWaitingArea(maximumPlayers) {
+      return await new Promise((resolve) => {
+        redisClient.lrange(
+          WAITING_AREA_KEY,
+          0,
+          maximumPlayers,
+          (err, results) => resolve(results)
+        );
+      });
+    }
+
+    test("removes from an empty waiting area", async () => {
+      const {
+        players,
+        preempted,
+      } = await redisDataStore.removePlayersFromWaitingArea();
+
+      expect(preempted).toBe(false);
+      expect(players).toEqual([]);
+    });
+
+    test("removes from the front", async () => {
+      const waitingPlayers = [
+        {
+          id: "p1",
+          name: "Washington",
+        },
+        {
+          id: "p2",
+          name: "Irving",
+        },
+        {
+          id: "p3",
+          name: "John",
+        },
+      ];
+
+      await redisDataStore.addPlayerToWaitingArea(waitingPlayers[0]);
+      await redisDataStore.addPlayerToWaitingArea(waitingPlayers[1]);
+      await redisDataStore.addPlayerToWaitingArea(waitingPlayers[2]);
+
+      const {
+        players,
+        preempted,
+      } = await redisDataStore.removePlayersFromWaitingArea();
+
+      expect(preempted).toBe(false);
+      expect(players).toEqual(waitingPlayers);
+
+      const remainingPlayers = await getPlayersInWaitingArea(10);
+      expect(remainingPlayers).toEqual([]);
+    });
+  });
+
+  describe("setPlayerAnswer", () => {
+    async function getPlayerAnswer(playerId, gameId, round) {
+      const key = `${gameId}:${round}`;
+      return await new Promise((resolve) => {
+        redisClient.hmget(key, playerId, (err, result) =>
+          resolve(parseInt(result[0], 10))
+        );
+      });
+    }
+
+    test("adds an answer to a nonexisting key", async () => {
+      redisDataStore.setPlayerAnswer("A", 0, "G", 1);
+
+      const answerIndex = await getPlayerAnswer("A", "G", 1);
+      expect(answerIndex).toBe(0);
+    });
+
+    test("adds an answer to an existing key", async () => {
+      redisDataStore.setPlayerAnswer("A", 0, "G", 1);
+      redisDataStore.setPlayerAnswer("B", 2, "G", 1);
+
+      const answerIndex = await getPlayerAnswer("B", "G", 1);
+      expect(answerIndex).toBe(2);
+    });
+
+    test("overwrites existing answers", async () => {
+      redisDataStore.setPlayerAnswer("A", 0, "G", 1);
+      redisDataStore.setPlayerAnswer("A", 2, "G", 1);
+
+      const answerIndex = await getPlayerAnswer("A", "G", 1);
+      expect(answerIndex).toBe(2);
+    });
+  });
+});

--- a/worker/tests/stubRedisClient.js
+++ b/worker/tests/stubRedisClient.js
@@ -4,7 +4,7 @@ class StubRedisClient {
   }
 
   hgetall(key, cb) {
-    return cb(undefined, this.data[key] || null);
+    cb(undefined, this.data[key] || null);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,6 +3110,11 @@ redis-commands@^1.2.0:
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.5.0.tgz#80d2e20698fe688f227127ff9e5164a7dd17e785"
   integrity sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==
 
+redis-mock@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/redis-mock/-/redis-mock-0.49.0.tgz#744c38dde3caae4c9ca70e2a674c4bb30eb607ca"
+  integrity sha512-FW/cLZvF1PAVN/PYIwXf1vQRoJCyYCwUMtq8BXRwrvb9LNNAT4RKXM02Qlt6qSkC/98hmHlU2EGoQoxVy3E2lA==
+
 redis-parser@^2.5.0, redis-parser@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"


### PR DESCRIPTION
This change adds a `RedisDataStore` object that abstracts away the Redis operations performed by the web frontend. These operations include managing the player waiting area and the player answers.

Player answers are simply stored in a know hash keyed on game and round so that the worker can perform an `HGETALL` operation to get all player answers.

The waiting area is a bit more complex because multiple web frontends will be reading and writing to it at the same time.

The waiting area is managed as a Redis list of serialized player information. A web frontend can add a player to the waiting area by pushing that player's information to the end of that list. If the list is long enough to start a game the web frontend will remove that many players from the list and start a new game with those players.

The interesting aspect is that while one web frontend is removing players another may be adding players and subsequently also deciding to start a new game with them. To manage this we watch a lock key that will only allow players to be removed from the list if the lock hasn't been set since the list was read. The lock's value is set in the same Redis transaction as removing the players and so only one web frontend will be able to successfully remove players.

A web frontend that detects that it hasn't been able to successfully remove players will know that another web frontend got to it first. It's possible that the player it just added will not be part of the new game but that's ok. That player instead waits for enough players for the next game to start without issue.

A final aspect of the waiting area is that we don't attempt to remove players that have been waiting but subsequently disconnected from the game. Those players' information will be sent as valid game players but they will be eliminated from the first round since they won't provide an answer. This won't affect other players' experiences because they have no way of knowing if a different player answered incorrectly, failed to answer, or isn't connected.