### PR TITLE
Add missing `answer` method

### DIFF
--- a/js/dataChannel.js
+++ b/js/dataChannel.js
@@ -82,6 +82,15 @@ class DataChannel extends EventTarget {
 
     sendData({ type: "join" }, this.socket);
   }
+
+  answer(answerIndex) {
+    if (this.readyState !== WebSocket.OPEN) {
+      emitError("Not connected", this);
+      return;
+    }
+
+    sendData({ type: "answer", answerIndex }, this.socket);
+  }
 }
 
 // Make this work in both browser and Node environments

--- a/tests/dataChannel.spec.js
+++ b/tests/dataChannel.spec.js
@@ -136,4 +136,28 @@ describe("DataChannel", () => {
       });
     });
   });
+
+  describe("answer", () => {
+    test("emits an error if not connected", () => {
+      const dataChannel = new DataChannel("", "Washington");
+
+      dataChannel.addEventListener("error", (event) => {
+        expect(event.message).toEqual("Not connected");
+      });
+
+      dataChannel.answer(0);
+    });
+
+    test("send an answer message if connected", () => {
+      const dataChannel = new DataChannel("", "Washington");
+      dataChannel.connect();
+      dataChannel.joinGame();
+      dataChannel.answer(0);
+
+      expect(dataChannel.socket.sendCallback).toHaveBeenCalledWith({
+        type: "answer",
+        answerIndex: 0,
+      });
+    });
+  });
 });


### PR DESCRIPTION
This change adds the missing `answer` method to `DataChannel`. This method was forgotten in the last change but is required for the client to be able to send answers.