### PR TITLE
Use an environment variable to control the minimum players per game

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -37,7 +37,7 @@ const pingInterval = setInterval(() => {
   });
 }, 10000);
 
-const MINIMUM_PLAYERS_PER_GAME = 1;
+const MINIMUM_PLAYERS_PER_GAME = process.env.MINIMUM_PLAYERS_PER_GAME || 1;
 
 async function joinGame(player) {
   const playerCount = await redisDataStore.addPlayerToWaitingArea(player);


### PR DESCRIPTION
This change switches to use an environment variable to control the minimum players per game. This esures new code doesn't need to be pushed to update this value.