### PR TITLE
Ensure the environment variable is an integer

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -37,7 +37,10 @@ const pingInterval = setInterval(() => {
   });
 }, 10000);
 
-const MINIMUM_PLAYERS_PER_GAME = process.env.MINIMUM_PLAYERS_PER_GAME || 1;
+const MINIMUM_PLAYERS_PER_GAME = parseInt(
+  process.env.MINIMUM_PLAYERS_PER_GAME || "1",
+  10
+);
 
 async function joinGame(player) {
   const playerCount = await redisDataStore.addPlayerToWaitingArea(player);


### PR DESCRIPTION
This fixes a bug in which the `MINIMUM_PLAYERS_PER_GAME` environment variable could be set to a string.